### PR TITLE
Skip attachment collection for placeholder token and add local smoke-test spec

### DIFF
--- a/scripts/swaif_stage.sh
+++ b/scripts/swaif_stage.sh
@@ -66,14 +66,14 @@ fi
 
 # collect attachments (best-effort)
 if [[ "${stage}" == "init" || "${stage}" == "specify" ]]; then
-  if [[ -n "${PROJECTS_TOKEN:-}" && -n "${GITHUB_REPOSITORY:-}" ]]; then
+  if [[ -n "${PROJECTS_TOKEN:-}" && -n "${GITHUB_REPOSITORY:-}" && "${PROJECTS_TOKEN}" != "placeholder-token" ]]; then
     python3 scripts/swaif_collect_attachments.py \
       --repo "${GITHUB_REPOSITORY}" \
       --issue "${issue_number}" \
       --token "${PROJECTS_TOKEN}" \
       --out "${feature_dir}/attachments" || true
   else
-    echo "Sem token/repo; pulei coleta de anexos."
+    echo "Sem token/repo válido; pulei coleta de anexos."
   fi
 fi
 

--- a/specs/001-smoke-test/intake.md
+++ b/specs/001-smoke-test/intake.md
@@ -1,0 +1,4 @@
+<!-- AUTO-GENERATED from GitHub Issue #9999 -->
+<!-- Title: Smoke Test -->
+
+Smoke issue body

--- a/specs/001-smoke-test/plan.md
+++ b/specs/001-smoke-test/plan.md
@@ -1,0 +1,1 @@
+# Plan — 001-smoke-test\n\n> Stack e arquitetura.\n

--- a/specs/001-smoke-test/spec.md
+++ b/specs/001-smoke-test/spec.md
@@ -1,0 +1,1 @@
+# Spec — 001-smoke-test\n\n> Baseado em intake.md.\n

--- a/specs/001-smoke-test/tasks.md
+++ b/specs/001-smoke-test/tasks.md
@@ -1,0 +1,1 @@
+# Tasks — 001-smoke-test\n\n> Tarefas pequenas com critério de aceite.\n


### PR DESCRIPTION
### Motivation
- Allow running the local stage runner for smoke tests without a real GitHub token by treating `placeholder-token` as invalid to avoid noisy GitHub API auth errors.
- Produce a minimal local spec scaffolding under `specs/001-smoke-test/` so developers can validate the pipeline locally without GitHub Actions.

### Description
- Update `scripts/swaif_stage.sh` to skip attachment collection when `PROJECTS_TOKEN` is empty or equals `placeholder-token` and adjust the log message to "Sem token/repo válido; pulei coleta de anexos.".
- Generate the smoke-test spec files `specs/001-smoke-test/intake.md`, `specs/001-smoke-test/spec.md`, `specs/001-smoke-test/plan.md`, and `specs/001-smoke-test/tasks.md` via the `init` stage run.
- Commit includes the modified `scripts/swaif_stage.sh` and the newly created files under `specs/001-smoke-test/`.

### Testing
- An initial run of `./scripts/swaif_stage.sh` failed with `Permission denied`, so the runner was invoked with `bash ./scripts/swaif_stage.sh` which executed successfully.
- Executed `ISSUE_BODY='Smoke issue body' GITHUB_REPOSITORY='owner/repo' PROJECTS_TOKEN='placeholder-token' bash ./scripts/swaif_stage.sh "Smoke Test" init "specs/001-smoke-test" "MVP" "9999" "suggest"` and it completed without GitHub API errors for the placeholder token.
- Verified the four expected files exist: `specs/001-smoke-test/intake.md`, `specs/001-smoke-test/spec.md`, `specs/001-smoke-test/plan.md`, and `specs/001-smoke-test/tasks.md`, and the commit was created successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a8ff0a3db883269a1d9880f813f196)