### PR TITLE
fix: add token fallback for SWAIF IssueOps workflow

### DIFF
--- a/.github/workflows/issueops-swaif-factory.yml
+++ b/.github/workflows/issueops-swaif-factory.yml
@@ -40,7 +40,7 @@ jobs:
     timeout-minutes: 30
 
     env:
-      PROJECTS_TOKEN: ${{ secrets.PROJECTS_SECRET }}
+      PROJECTS_TOKEN: ${{ secrets.PROJECTS_SECRET || github.token }}
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       SWAIF_MODEL: ${{ vars.SWAIF_MODEL }}
 


### PR DESCRIPTION
### Motivation
- Prevent the IssueOps workflow from failing when `secrets.PROJECTS_SECRET` is not configured by falling back to the default `github.token` so actions that call the API still have an auth token.

### Description
- Changed the `PROJECTS_TOKEN` environment in `.github/workflows/issueops-swaif-factory.yml` to use `secrets.PROJECTS_SECRET || github.token` as a minimal, non-invasive fix.

### Testing
- Verified the workflow YAML parses with `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/issueops-swaif-factory.yml')"` which returned success; attempts to run `gh auth status` failed because `gh` is not installed and there is no GitHub remote in this environment, so full E2E run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69a90116724883269c512869e68067c9)